### PR TITLE
Add Pathways on the Image Manifold paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Harold Haodong Chen, Disen Lan, Wen-Jie Shu, Qingyang Liu, Zihan Wang, Sirui Che
 Thaddäus Wiedemer, Yuxuan Li, Paul Vicol, Shixiang Shane Gu, Nick Matarese, Kevin Swersky, Been Kim, Priyank Jaini, Robert Geirhos  
 📄 [Paper](https://arxiv.org/abs/2509.20328) | 💻 [Project](https://video-zero-shot.github.io/)
 
+### 2024
+
+**Pathways on the Image Manifold: Image Editing via Video Generation** | *Nov 2024*  
+Noam Rotstein, Gal Yona, Daniel Silver, Roy Velich, David Bensaïd, Ron Kimmel  
+📄 [Paper](https://arxiv.org/abs/2411.16819) | 💻 [Project](https://rotsteinnoam.github.io/Frame2Frame/)
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a pull request to add new papers or resources.


### PR DESCRIPTION
Adds "Pathways on the Image Manifold: Image Editing via Video Generation" to the README paper list.

- arXiv: https://arxiv.org/abs/2411.16819
- Project: https://rotsteinnoam.github.io/Frame2Frame/
- Added under 2024 (Nov 2024) based on the arXiv v1 submission date.